### PR TITLE
feat: support to image-choice and buttons input

### DIFF
--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/convertInputToWhatsappComponent.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/convertInputToWhatsappComponent.ts
@@ -1,6 +1,6 @@
 import { ContinueChatResponse } from '@typebot.io/schemas'
 import { InputBlockType } from '@typebot.io/schemas/features/blocks/inputs/constants'
-import { WhatsappSocketSendingMessage } from './convertMessageToWhatsappCompoent'
+import { TypeWhatsappMessage, WhatsappSocketSendingMessage } from './convertMessageToWhatsappCompoent'
 
 export const convertInputToWhatsAppComponent = (
   input: NonNullable<ContinueChatResponse['input']>,
@@ -16,6 +16,48 @@ export const convertInputToWhatsAppComponent = (
     case InputBlockType.RATING:
     case InputBlockType.TEXT:
       return []
+    case InputBlockType.PICTURE_CHOICE:
+        const items = input.items.flatMap((item, idx) => {
+          let bodyText = ''
+          if(item.title) bodyText += `*${item.title}*`
+          if(item.description) {
+            if(item.title) bodyText += `\n\n`
+            bodyText += item.description
+          }
+          const imageMessage = item.pictureSrc
+          ? ({
+            type: TypeWhatsappMessage.IMAGE,
+            body: item.pictureSrc ?? ''
+          }) : undefined
+          const textMessage = {
+            type: TypeWhatsappMessage.TEXT,
+            body: `${idx + 1}. ${bodyText}`
+          }
+          return imageMessage ? [imageMessage, textMessage] : [textMessage]
+        })
+        let initialMessage = '*Selecione uma opção abaixo:*\nDigite o título da opção desejada.';
+        if(input.options?.isMultipleChoice) {
+          initialMessage = '*Selecione uma ou mais opções abaixo:*\nDigite os títulos das opções separados por vírgula.';
+        }
+        items.unshift({
+          type: TypeWhatsappMessage.TEXT,
+          body: initialMessage
+        })
+        return items as WhatsappSocketSendingMessage[]
+    case InputBlockType.CHOICE: {
+      let initialMessage = '*Digite a opção desejada.*\n';
+      if(input.options?.isMultipleChoice) {
+        initialMessage = '*Digite as opções desejadas separados por vírgula.*\n';
+      }
+      return [
+        {
+          type: TypeWhatsappMessage.TEXT,
+          body: initialMessage.concat(
+            input.items.map((item) => `- ${item.content}`).join('\n')
+          )
+        }
+      ]
+    }
     default:
       throw new Error('Unsupported input type')
   }

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/convertMessageToWhatsappCompoent.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/convertMessageToWhatsappCompoent.ts
@@ -4,10 +4,21 @@ import { VideoBubbleContentType } from '@typebot.io/schemas/features/blocks/bubb
 import { serialize } from 'remark-slate'
 import { isImageUrlNotCompatible, isVideoUrlNotCompatible } from '../convertMessageToWhatsAppMessage'
 
+export enum TypeWhatsappMessage {
+  TEXT = 'text',
+  IMAGE = 'image',
+  AUDIO = 'audio',
+  VIDEO = 'video',
+  EMBED = 'embed',
+  INTERACTIVE = 'interactive'
+}
 
 export type WhatsappSocketSendingMessage = {
-  type: 'text' | 'image' | 'audio' | 'video' | 'embed'
+  type: TypeWhatsappMessage.TEXT | TypeWhatsappMessage.EMBED | TypeWhatsappMessage.IMAGE | TypeWhatsappMessage.VIDEO | TypeWhatsappMessage.AUDIO
   body: string
+} | {
+  type: TypeWhatsappMessage.INTERACTIVE
+  interactive: Record<string, any>
 }
 
 export const convertMessageToWhatsappComponent = (
@@ -18,7 +29,7 @@ export const convertMessageToWhatsappComponent = (
       if (!message.content.richText || message.content.richText.length === 0)
         return
       return {
-        type: 'text',
+        type: TypeWhatsappMessage.TEXT,
         body:  message.content.richText
         .map((chunk) =>
           serialize(chunk)?.replaceAll('&amp;amp;#39;', "'").replaceAll('**', '*')
@@ -30,14 +41,14 @@ export const convertMessageToWhatsappComponent = (
       if (!message.content.url || isImageUrlNotCompatible(message.content.url))
         return
       return {
-        type: 'image',
+        type: TypeWhatsappMessage.IMAGE,
         body: message.content.url,
       }
     }
     case BubbleBlockType.AUDIO: {
       if (!message.content.url) return
       return {
-        type: 'audio',
+        type: TypeWhatsappMessage.AUDIO,
         body: message.content.url,
       }
     }
@@ -49,14 +60,14 @@ export const convertMessageToWhatsappComponent = (
       )
         return
       return {
-        type: 'video',
+        type: TypeWhatsappMessage.VIDEO,
         body: message.content.url,
       }
     }
     case BubbleBlockType.EMBED: {
       if (!message.content.url) return
       return {
-        type: 'embed',
+        type: TypeWhatsappMessage.EMBED,
         body: message.content.url,
       }
     }


### PR DESCRIPTION
Suporte para os tipos "choice" e "image choice".

Tentei usar os botões do whatsapp web js, mas não estavam funcionando, e por algum motivo o fix ainda não está no código main da lib webWhatsappJs, porém fiz umas tratativas temporárias para esses inputs.

A intenção é enviar uma mensagem com todas as opções para determinada escolha e aguardar a resposta do usuário.

Ainda não é a melhor solução, mas é uma solução paliativa até os botões do whatsapp estarem corrigidos nas próximas releases do webWhatsappJs

![Captura de tela 2024-01-22 164650](https://github.com/funnelhub-io/typebot.io/assets/69400902/05dd4a9f-01a4-41ba-a096-941bd4f3c81e)
![Captura de tela 2024-01-22 165516](https://github.com/funnelhub-io/typebot.io/assets/69400902/be4a32ec-2468-46ce-b127-8b5a3f0d4f47)
