### PR TITLE
Inserção da rota da api de usuários em uma rota pública existente

### DIFF
--- a/apps/builder/src/helpers/server/routers/publicRouter.ts
+++ b/apps/builder/src/helpers/server/routers/publicRouter.ts
@@ -12,6 +12,7 @@ import { collaboratorsRouter } from '@/features/collaboration/api/router'
 import { customDomainsRouter } from '@/features/customDomains/api/router'
 import { processTelemetryEvent } from '@/features/telemetry/api/processTelemetryEvent'
 import { publicWhatsAppRouter } from '@/features/whatsapp/router'
+import { userRouter } from '@/features/account/api/router'
 
 export const publicRouter = router({
   getLinkedTypebots,
@@ -27,6 +28,7 @@ export const publicRouter = router({
   customDomains: customDomainsRouter,
   processTelemetryEvent,
   whatsApp: publicWhatsAppRouter,
+  users: userRouter,
 })
 
 export type PublicRouter = typeof publicRouter


### PR DESCRIPTION
Em meio às atualizações originadas pelo merge do repositório do Baptiste, a rota que armazenava os endpoints do usuário foi excluída, ocasionando erro de NOT_FOUND ao tentar cadastrar um usuário pelo Funnel Hub.