### PR TITLE
fix: parse quotes code to symbol

### DIFF
--- a/apps/builder/src/features/blocks/integrations/whatsapp/components/WhatsappCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/whatsapp/components/WhatsappCredentialsModal.tsx
@@ -70,6 +70,12 @@ export const WhatsappCredentialsModal = ({
     },
   })
 
+  const handleBackToOriginalState = () => {
+    setStepLoadingMessage(stepMessages.loadingQrCode)
+    setProcessAuthWppLoading(true)
+    setWhatsappQrCode(null)
+  }
+
   const handleStartWebsocket = useCallback(async () => {
     if (!workspace || !typebot) return
 
@@ -110,9 +116,7 @@ export const WhatsappCredentialsModal = ({
                 },
               },
             })
-            setStepLoadingMessage(stepMessages.loadingQrCode)
-            setProcessAuthWppLoading(true)
-            setWhatsappQrCode(null)
+            handleBackToOriginalState()
         }
       }
     }
@@ -122,6 +126,7 @@ export const WhatsappCredentialsModal = ({
 
   const handleEndWebSocket = useCallback(() => {
     socketRef.current?.close()
+    handleBackToOriginalState()
     onClose()
   }, [onClose])
 

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/convertMessageToWhatsappCompoent.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/convertMessageToWhatsappCompoent.ts
@@ -32,7 +32,7 @@ export const convertMessageToWhatsappComponent = (
         type: TypeWhatsappMessage.TEXT,
         body:  message.content.richText
         .map((chunk) =>
-          serialize(chunk)?.replaceAll('&amp;amp;#39;', "'").replaceAll('**', '*')
+          serialize(chunk)?.replaceAll('&amp;amp;#39;', "'").replaceAll('**', '*').replaceAll('&amp;quot;', '"')
         )
         .join('\n')
       }


### PR DESCRIPTION
Basicamente é uma correção de parseamento de mensagem, quando o cliente enviava uma mensagem com aspas (") aparecia um código estranho, apenas fiz o parse para aparecerem as aspas ao invés do código estranho


![Captura de tela 2024-01-30 112120](https://github.com/funnelhub-io/typebot.io/assets/69400902/2ed46afb-2c05-4a77-9c5b-f8af44692f94)
![Captura de tela 2024-01-30 112152](https://github.com/funnelhub-io/typebot.io/assets/69400902/5e17aafa-1131-4f65-933a-47a1491e648a)

Também corrige o problema voltar ao estado original o componente de credenciais de whatsapp que o Daniel tinha reportado