### PR TITLE
fix: run pnpm install before to run turbo prune in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ FROM base AS pruner
 RUN npm --global install turbo
 WORKDIR /app
 COPY . .
+RUN pnpm install
 RUN turbo prune --scope=${SCOPE} --docker
+RUN find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 
 FROM base AS builder
 RUN apt-get -qy update && apt-get -qy --no-install-recommends install openssl git


### PR DESCRIPTION
# Problema ao rodar o build

- Tive que rodar um pnpm install antes de rodar o turbo prune 
- Dps tive que deletar as node_modules pois daria erro novamente em outro local quando fosse criar a etapa de builder