### PR TITLE
fix: rerender new qrcode on auth failure with message error

### DIFF
--- a/apps/builder/src/i18n/de.json
+++ b/apps/builder/src/i18n/de.json
@@ -152,6 +152,7 @@
   "editor.blocks.integrations.whatsapp.WhatsappCredentialsModal.ModalHeader": "WhatsApp-Konto hinzufügen",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.loadingQrCode": "QR-Code generieren...",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.processingAuthentication": "Authentifizierung wird verarbeitet",
+  "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.authFailure": "Authentifizierungsfehler, bitte den QR-Code erneut lesen.",
   "editor.credentialsDropdown.add.label": "Hinzufügen",
   "editor.credentialsDropdown.ConnectNew.label": "Neu verbinden",
   "editor.gettingStartedModal.editorBasics.heading": "Grundlagen des Editors",

--- a/apps/builder/src/i18n/en.json
+++ b/apps/builder/src/i18n/en.json
@@ -261,6 +261,7 @@
   "editor.blocks.integrations.whatsapp.WhatsappCredentialsModal.ModalHeader": "Add Whatsapp account",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.loadingQrCode": "Generating QR code...",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.processingAuthentication": "Processing authentication...",
+  "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.authFailure": "Authentication failure, please scan the QR code again.",
   "editor.credentialsDropdown.add.label": "Add",
   "editor.credentialsDropdown.ConnectNew.label": "Connect new",
   "editor.gettingStartedModal.editorBasics.heading": "Editor Basics",

--- a/apps/builder/src/i18n/es.json
+++ b/apps/builder/src/i18n/es.json
@@ -212,6 +212,7 @@
   "editor.blocks.integrations.whatsapp.WhatsappCredentialsModal.ModalHeader": "Agregar cuenta de WhatsApp",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.loadingQrCode": "Generando código QR...",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.processingAuthentication": "Procesando autenticación...",
+  "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.authFailure": "Fallo de autenticación, vuelva a leer el código QR.",
   "editor.credentialsDropdown.add.label": "Agregar",
   "editor.credentialsDropdown.ConnectNew.label": "Conectar nuevo",
   "errorMessage": "Se produjo un error",

--- a/apps/builder/src/i18n/fr.json
+++ b/apps/builder/src/i18n/fr.json
@@ -227,6 +227,7 @@
   "editor.blocks.integrations.whatsapp.WhatsappCredentialsModal.ModalHeader": "Ajouter un compte WhatsApp",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.loadingQrCode": "Génération du code QR...",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.processingAuthentication": "Traitement de l'authentification...",
+  "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.authFailure": "Échec de l'authentification, veuillez relire le code QR.",
   "editor.credentialsDropdown.add.label": "Ajouter",
   "editor.credentialsDropdown.ConnectNew.label": "Connecter un nouveau",
   "emojiList.categories.activities.label": "ACTIVITÉS",

--- a/apps/builder/src/i18n/pt-BR.json
+++ b/apps/builder/src/i18n/pt-BR.json
@@ -330,6 +330,7 @@
   "editor.blocks.integrations.whatsapp.WhatsappCredentialsModal.ModalHeader": "Adicionar conta WhatsApp",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.loadingQrCode": "Gerando código QR...",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.processingAuthentication": "Processando autenticação...",
+  "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.authFailure": "Falha na autenticação, leia novamente o QR code.",
   "editor.credentialsDropdown.add.label": "Adicionar",
   "editor.credentialsDropdown.ConnectNew.label": "Conectar novo",
   "emojiList.categories.activities.label": "ATIVIDADES",

--- a/apps/builder/src/i18n/pt.json
+++ b/apps/builder/src/i18n/pt.json
@@ -212,6 +212,7 @@
   "editor.blocks.integrations.whatsapp.WhatsappCredentialsModal.ModalHeader": "Adicionar conta WhatsApp",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.loadingQrCode": "Gerando código QR...",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.processingAuthentication": "Processando autenticação...",
+  "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.authFailure": "Falha na autenticação, leia novamente o QR code.",
   "editor.credentialsDropdown.add.label": "Adicionar",
   "editor.credentialsDropdown.ConnectNew.label": "Conectar novo",
   "errorMessage": "Ocorreu um erro",

--- a/apps/builder/src/i18n/ro.json
+++ b/apps/builder/src/i18n/ro.json
@@ -212,6 +212,7 @@
   "editor.blocks.integrations.whatsapp.WhatsappCredentialsModal.ModalHeader": "Adăugare cont WhatsApp",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.loadingQrCode": "Generare cod QR...",
   "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.processingAuthentication": "Procesare autentificare...",
+  "editor.blocks.integrations.whatsapp.WhatsappCredetialsModal.authFailure": "Autentificare eșuată, vă rugăm să recitiți codul QR.",
   "editor.credentialsDropdown.add.label": "Adăugare",
   "editor.credentialsDropdown.ConnectNew.label": "Conectare nou",
   "errorMessage": "A aparut o eroare",


### PR DESCRIPTION
# Renderizar qr code em caso de falhas

- Em caso de falha, quando o processo de autenticação dá erro é renderizado novamente o novo qr code
- Também renderizei uma mensagem de erro informando que deu problema e é para ele escanear novamente o qr code.

Foto ilustrativa :D 

![Captura de tela 2024-01-31 160053](https://github.com/funnelhub-io/typebot.io/assets/69400902/e8848cf6-97c6-470c-aa7e-bd11b1e9488f)
