### PR TITLE
fix: execute client side actions when whatsapp component is between b…

### DIFF
--- a/apps/viewer/src/features/chat/api/continueChat.ts
+++ b/apps/viewer/src/features/chat/api/continueChat.ts
@@ -99,7 +99,7 @@ export const continueChat = publicProcedure
       return {
         messages: [],
         input: undefined,
-        clientSideActions: undefined,
+        clientSideActions: [],
         dynamicTheme: undefined,
         logs: [],
         lastMessageNewFormat: undefined,
@@ -112,7 +112,9 @@ export const continueChat = publicProcedure
     return {
       messages,
       input: newSessionState?.whatsappComponent?.canExecute ? undefined : input,
-      clientSideActions,
+      clientSideActions: newSessionState?.whatsappComponent?.canExecute
+        ? []
+        : clientSideActions,
       dynamicTheme: parseDynamicTheme(newSessionState),
       logs: isPreview ? logs : logs?.filter(filterPotentiallySensitiveLogs),
       lastMessageNewFormat,

--- a/apps/viewer/src/features/chat/api/continueChat.ts
+++ b/apps/viewer/src/features/chat/api/continueChat.ts
@@ -1,6 +1,7 @@
 import { publicProcedure } from '@/helpers/server/trpc'
 import { TRPCError } from '@trpc/server'
 import { continueBotFlow } from '@typebot.io/bot-engine/continueBotFlow'
+import { filterPotentiallySensitiveLogs } from '@typebot.io/bot-engine/logs/filterPotentiallySensitiveLogs'
 import { parseDynamicTheme } from '@typebot.io/bot-engine/parseDynamicTheme'
 import { getSession } from '@typebot.io/bot-engine/queries/getSession'
 import { saveStateToDatabase } from '@typebot.io/bot-engine/saveStateToDatabase'
@@ -8,7 +9,6 @@ import { executeWhatsappFlow } from '@typebot.io/bot-engine/whatsapp/WhatsappCom
 import { isDefined, isNotDefined } from '@typebot.io/lib/utils'
 import { continueChatResponseSchema } from '@typebot.io/schemas/features/chat/schema'
 import { z } from 'zod'
-import { filterPotentiallySensitiveLogs } from '@typebot.io/bot-engine/logs/filterPotentiallySensitiveLogs'
 
 export const continueChat = publicProcedure
   .meta({
@@ -89,7 +89,7 @@ export const continueChat = publicProcedure
         visitedEdges,
       })
 
-    if (newSessionState.whatsappComponent) {
+    if (newSessionState.whatsappComponent?.canExecute) {
       await executeWhatsappFlow({
         state: newSessionState,
         messages,

--- a/apps/viewer/src/features/chat/api/continueChat.ts
+++ b/apps/viewer/src/features/chat/api/continueChat.ts
@@ -111,7 +111,7 @@ export const continueChat = publicProcedure
 
     return {
       messages,
-      input,
+      input: newSessionState?.whatsappComponent?.canExecute ? undefined : input,
       clientSideActions,
       dynamicTheme: parseDynamicTheme(newSessionState),
       logs: isPreview ? logs : logs?.filter(filterPotentiallySensitiveLogs),

--- a/apps/viewer/src/features/chat/api/startChat.ts
+++ b/apps/viewer/src/features/chat/api/startChat.ts
@@ -1,4 +1,5 @@
 import { publicProcedure } from '@/helpers/server/trpc'
+import { filterPotentiallySensitiveLogs } from '@typebot.io/bot-engine/logs/filterPotentiallySensitiveLogs'
 import { restartSession } from '@typebot.io/bot-engine/queries/restartSession'
 import { saveStateToDatabase } from '@typebot.io/bot-engine/saveStateToDatabase'
 import { startSession } from '@typebot.io/bot-engine/startSession'
@@ -7,7 +8,6 @@ import {
   startChatInputSchema,
   startChatResponseSchema,
 } from '@typebot.io/schemas/features/chat/schema'
-import { filterPotentiallySensitiveLogs } from '@typebot.io/bot-engine/logs/filterPotentiallySensitiveLogs'
 
 export const startChat = publicProcedure
   .meta({
@@ -81,7 +81,7 @@ export const startChat = publicProcedure
             visitedEdges,
           })
 
-      if (newSessionState.whatsappComponent) {
+      if (newSessionState.whatsappComponent?.canExecute) {
         await executeWhatsappFlow({
           state: { ...newSessionState, sessionId: session.id },
           messages,

--- a/apps/viewer/src/features/chat/api/startChat.ts
+++ b/apps/viewer/src/features/chat/api/startChat.ts
@@ -97,7 +97,7 @@ export const startChat = publicProcedure
             settings: typebot.settings,
           },
           messages: [],
-          input,
+          input: undefined,
           resultId,
           dynamicTheme: undefined,
           logs: [],
@@ -113,7 +113,9 @@ export const startChat = publicProcedure
           settings: typebot.settings,
         },
         messages,
-        input,
+        input: newSessionState?.whatsappComponent?.canExecute
+          ? undefined
+          : input,
         resultId,
         dynamicTheme,
         logs: logs?.filter(filterPotentiallySensitiveLogs),

--- a/apps/viewer/src/features/chat/api/startChat.ts
+++ b/apps/viewer/src/features/chat/api/startChat.ts
@@ -119,7 +119,9 @@ export const startChat = publicProcedure
         resultId,
         dynamicTheme,
         logs: logs?.filter(filterPotentiallySensitiveLogs),
-        clientSideActions,
+        clientSideActions: newSessionState?.whatsappComponent?.canExecute
+          ? []
+          : clientSideActions,
       }
     }
   )

--- a/apps/viewer/src/features/chat/api/startChatPreview.ts
+++ b/apps/viewer/src/features/chat/api/startChatPreview.ts
@@ -69,7 +69,7 @@ export const startChatPreview = publicProcedure
             visitedEdges,
           })
 
-      if (newSessionState.whatsappComponent) {
+      if (newSessionState.whatsappComponent?.canExecute) {
         await executeWhatsappFlow({
           state: { ...newSessionState, sessionId: session.id },
           messages,

--- a/apps/viewer/src/features/chat/api/startChatPreview.ts
+++ b/apps/viewer/src/features/chat/api/startChatPreview.ts
@@ -105,7 +105,9 @@ export const startChatPreview = publicProcedure
           : input,
         dynamicTheme,
         logs,
-        clientSideActions,
+        clientSideActions: newSessionState?.whatsappComponent?.canExecute
+          ? []
+          : clientSideActions,
       }
     }
   )

--- a/apps/viewer/src/features/chat/api/startChatPreview.ts
+++ b/apps/viewer/src/features/chat/api/startChatPreview.ts
@@ -85,7 +85,7 @@ export const startChatPreview = publicProcedure
             settings: typebot.settings,
           },
           messages: [],
-          input,
+          input: undefined,
           dynamicTheme: undefined,
           logs: [],
           clientSideActions: [],
@@ -100,7 +100,9 @@ export const startChatPreview = publicProcedure
           settings: typebot.settings,
         },
         messages,
-        input,
+        input: newSessionState?.whatsappComponent?.canExecute
+          ? undefined
+          : input,
         dynamicTheme,
         logs,
         clientSideActions,

--- a/packages/bot-engine/executeGroup.ts
+++ b/packages/bot-engine/executeGroup.ts
@@ -1,10 +1,6 @@
-import {
-  ContinueChatResponse,
-  Group,
-  InputBlock,
-  RuntimeOptions,
-  SessionState,
-} from '@typebot.io/schemas'
+import { createId } from '@paralleldrive/cuid2'
+import { TRPCError } from '@trpc/server'
+import { env } from '@typebot.io/env'
 import {
   isBubbleBlock,
   isInputBlock,
@@ -12,25 +8,29 @@ import {
   isLogicBlock,
   isNotEmpty,
 } from '@typebot.io/lib'
-import { getNextGroup } from './getNextGroup'
-import { executeLogic } from './executeLogic'
-import { executeIntegration } from './executeIntegration'
-import { computePaymentInputRuntimeOptions } from './blocks/inputs/payment/computePaymentInputRuntimeOptions'
-import { injectVariableValuesInButtonsInputBlock } from './blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock'
-import { injectVariableValuesInPictureChoiceBlock } from './blocks/inputs/pictureChoice/injectVariableValuesInPictureChoiceBlock'
-import { getPrefilledInputValue } from './getPrefilledValue'
-import { parseDateInput } from './blocks/inputs/date/parseDateInput'
+import { VisitedEdge } from '@typebot.io/prisma'
+import {
+  ContinueChatResponse,
+  Group,
+  InputBlock,
+  RuntimeOptions,
+  SessionState,
+} from '@typebot.io/schemas'
+import { InputBlockType } from '@typebot.io/schemas/features/blocks/inputs/constants'
 import { deepParseVariables } from '@typebot.io/variables/deepParseVariables'
+import { injectVariableValuesInButtonsInputBlock } from './blocks/inputs/buttons/injectVariableValuesInButtonsInputBlock'
+import { parseDateInput } from './blocks/inputs/date/parseDateInput'
+import { computePaymentInputRuntimeOptions } from './blocks/inputs/payment/computePaymentInputRuntimeOptions'
+import { injectVariableValuesInPictureChoiceBlock } from './blocks/inputs/pictureChoice/injectVariableValuesInPictureChoiceBlock'
+import { executeIntegration } from './executeIntegration'
+import { executeLogic } from './executeLogic'
+import { getNextGroup } from './getNextGroup'
+import { getPrefilledInputValue } from './getPrefilledValue'
 import {
   BubbleBlockWithDefinedContent,
   parseBubbleBlock,
 } from './parseBubbleBlock'
-import { InputBlockType } from '@typebot.io/schemas/features/blocks/inputs/constants'
-import { VisitedEdge } from '@typebot.io/prisma'
-import { env } from '@typebot.io/env'
-import { TRPCError } from '@trpc/server'
 import { ExecuteIntegrationResponse, ExecuteLogicResponse } from './types'
-import { createId } from '@paralleldrive/cuid2'
 
 type ContextProps = {
   version: 1 | 2

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/resumeWhatsappComponentFlow.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/resumeWhatsappComponentFlow.ts
@@ -20,7 +20,7 @@ export async function resumeWhatsappComponentFlow({ message, sessionId }: Props)
 
   const { input, messages, newSessionState, clientSideActions, logs, visitedEdges} = await continueBotFlow(message, {
     version: 2,
-    state: session.state
+    state: {...session.state, sessionId }
   })
 
   await executeWhatsappFlow({

--- a/packages/embeds/js/src/features/blocks/integrations/whatsapp/loadWhatsappClient.ts
+++ b/packages/embeds/js/src/features/blocks/integrations/whatsapp/loadWhatsappClient.ts
@@ -1,0 +1,25 @@
+import { env } from '@typebot.io/env'
+
+export const executeLoadWhatsappClient = async (clientId: string) => {
+  await new Promise((resolve, reject) => {
+    const socket = new WebSocket(
+      `${env.NEXT_PUBLIC_WHATSAPP_SERVER}?clientId=${clientId}`
+    )
+    socket.onopen = () => console.log('Socket connected')
+    socket.onmessage = (event) => {
+      if (!event.data) return
+      const payloadParsed = JSON.parse(event.data ?? '{}')
+      if (payloadParsed.status === 'ready') {
+        resolve(payloadParsed)
+      }
+      if (payloadParsed.status === 'auth_failure') {
+        reject(
+          new Error(
+            'Falha na autenticação do whatsapp, leia o qr code novamente'
+          )
+        )
+      }
+    }
+  })
+  return { replyToSend: 'whatsappComponent' }
+}

--- a/packages/embeds/js/src/utils/executeClientSideActions.ts
+++ b/packages/embeds/js/src/utils/executeClientSideActions.ts
@@ -1,17 +1,18 @@
 import { executeChatwoot } from '@/features/blocks/integrations/chatwoot'
 import { executeGoogleAnalyticsBlock } from '@/features/blocks/integrations/googleAnalytics/utils/executeGoogleAnalytics'
 import { streamChat } from '@/features/blocks/integrations/openai/streamChat'
+import { executePixel } from '@/features/blocks/integrations/pixel/executePixel'
+import { executeWebhook } from '@/features/blocks/integrations/webhook/executeWebhook'
+import { executeLoadWhatsappClient } from '@/features/blocks/integrations/whatsapp/loadWhatsappClient'
 import { executeRedirect } from '@/features/blocks/logic/redirect'
 import {
-  executeScript,
   executeCode,
+  executeScript,
 } from '@/features/blocks/logic/script/executeScript'
 import { executeSetVariable } from '@/features/blocks/logic/setVariable/executeSetVariable'
 import { executeWait } from '@/features/blocks/logic/wait/utils/executeWait'
-import { executeWebhook } from '@/features/blocks/integrations/webhook/executeWebhook'
-import { executePixel } from '@/features/blocks/integrations/pixel/executePixel'
 import { ClientSideActionContext } from '@/types'
-import type { ContinueChatResponse, ChatLog } from '@typebot.io/schemas'
+import type { ChatLog, ContinueChatResponse } from '@typebot.io/schemas'
 import { injectStartProps } from './injectStartProps'
 
 type Props = {
@@ -86,5 +87,10 @@ export const executeClientSideAction = async ({
   }
   if ('codeToExecute' in clientSideAction) {
     return executeCode(clientSideAction.codeToExecute)
+  }
+  if ('whatsappComponent' in clientSideAction) {
+    return executeLoadWhatsappClient(
+      clientSideAction.whatsappComponent.clientId
+    )
   }
 }

--- a/packages/schemas/features/chat/clientSideAction.ts
+++ b/packages/schemas/features/chat/clientSideAction.ts
@@ -1,13 +1,13 @@
-import { z } from '../../zod'
 import { extendZodWithOpenApi } from 'zod-openapi'
-import { listVariableValue } from '../typebot/variable'
+import { z } from '../../zod'
 import {
-  googleAnalyticsOptionsSchema,
   executableWebhookSchema,
+  googleAnalyticsOptionsSchema,
   pixelOptionsSchema,
   redirectOptionsSchema,
 } from '../blocks'
 import { nativeMessageSchema } from '../blocks/integrations/openai'
+import { listVariableValue } from '../typebot/variable'
 
 extendZodWithOpenApi(z)
 
@@ -169,5 +169,17 @@ export const clientSideActionSchema = z.discriminatedUnion('type', [
     .openapi({
       ref: 'csaCodeToExecute',
       title: 'Execute code',
+    }),
+  z.
+    object({
+      type: z.literal('whatsappComponent'),
+      whatsappComponent: z.object({
+        clientId: z.string()
+      })
+    })
+    .merge(clientSideActionBaseSchema)
+    .openapi({
+      ref: 'whatsappComponent',
+      title: 'Load client'
     }),
 ])

--- a/packages/schemas/features/chat/sessionState.ts
+++ b/packages/schemas/features/chat/sessionState.ts
@@ -76,7 +76,8 @@ const sessionStateSchemaV2 = z.object({
     .optional(),
   whatsappComponent: z.object({
     phone: z.string(),
-    clientId: z.string()
+    clientId: z.string(),
+    canExecute: z.boolean()
   }).optional(),
   expiryTimeout: z
     .number()


### PR DESCRIPTION
# Correção de bug no flow do typebot

- Permitir que o fluxo pós componente interaja apenas dentro do whatsapp
- Permitir que fluxos pré componente interajam apenas dentro do client (chat) do typebot
- Fix dos inputs, agora não é renderizado os inputs mesmo quando o input é feito apenas pelo whatsapp
- Adiciona sessionId sempre que o webhook for chamado no estado do chat do typebot para n perder o contexto do flow
- Se um typebot inicia já com o primeiro bloco com o whatsapp então não será feito nada via clientSide, pois tudo ocorre dentro do contexto do whatsapp