### PR TITLE
fix: get first block by group and not by edge

### DIFF
--- a/packages/bot-engine/blocks/integrations/whatsapp/executeWhatsappBlock.ts
+++ b/packages/bot-engine/blocks/integrations/whatsapp/executeWhatsappBlock.ts
@@ -1,6 +1,7 @@
 import { decrypt } from "@typebot.io/lib/api/encryption/decrypt";
 import prisma from "@typebot.io/lib/prisma";
 import { ChatLog, SessionState, Variable, WhatsappBlock, WhatsappCredentials } from "@typebot.io/schemas";
+import { IntegrationBlockType } from "@typebot.io/schemas/features/blocks/integrations/constants";
 import { parseVariables } from '@typebot.io/variables/parseVariables';
 import { ExecuteIntegrationResponse } from "../../../types";
 
@@ -66,7 +67,10 @@ export const executeWhatsappBlock = async (
   })
 
   const firstEdge = state.typebotsQueue[0].typebot.edges.find(edge => firstEdgeId === edge.id)
-  return firstEdge?.to?.blockId === blockId ? { 
+  const firstGroupId = firstEdge?.to?.groupId
+  const firstGroup = state.typebotsQueue[0].typebot.groups.find(group => group.id === firstGroupId)
+
+  return firstGroup?.blocks[0].type === IntegrationBlockType.WHATSAPP ? { 
     outgoingEdgeId, 
     logs, 
     newSessionState: { 


### PR DESCRIPTION
# Selecionar primeiro bloco do typebot com base no grupo

- A seleção do primeiro bloco no typebot deve ser feita com base no primeiro grupo e não com base nas edges
- Assim consigo garantir que achei o primeiro bloco

Essa lógica acima é para que eu decida se posso iniciar todo o fluxo com whatsapp (se ele for o primeiro bloco de todos) ou caso tenha outros blocos antes dele fazer o flow antes do componente de whatsapp e dps fazer o swap
