### PR TITLE
feat: send operation type when socket is connected to whatsapp server

### DIFF
--- a/apps/builder/src/features/blocks/integrations/whatsapp/components/WhatsappCredentialsModal.tsx
+++ b/apps/builder/src/features/blocks/integrations/whatsapp/components/WhatsappCredentialsModal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@chakra-ui/react'
 import { createId } from '@paralleldrive/cuid2'
 import { useTranslate } from '@tolgee/react'
+import { WhatsappOperationTypes } from '@typebot.io/bot-engine/whatsapp/WhatsappComponentFlow/WhatsappOperationType'
 import { env } from '@typebot.io/env'
 import { useQRCode } from 'next-qrcode'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -96,6 +97,7 @@ export const WhatsappCredentialsModal = ({
       autoConnect: true,
       query: {
         clientId: `${workspace.id}_${now}`,
+        operationType: WhatsappOperationTypes.QR_CODE,
       },
     })
 

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/WhatsappOperationType.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/WhatsappOperationType.ts
@@ -1,0 +1,4 @@
+export enum WhatsappOperationTypes {
+  SEND_MESSAGE = 'send_message',
+  QR_CODE = 'qr_code'
+}

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/executeWhatsappFlow.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/executeWhatsappFlow.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
+import { TRPCError } from '@trpc/server'
 import { isNotDefined } from '@typebot.io/lib/utils'
 import { ContinueChatResponse, SessionState, Settings } from "@typebot.io/schemas"
 import { InputBlockType } from '@typebot.io/schemas/features/blocks/inputs/constants'
@@ -82,6 +83,7 @@ export async function executeWhatsappFlow({ state, messages, input, clientSideAc
       console.log('Failed to send message:', JSON.stringify(message, null, 2))
       if (err instanceof HTTPError)
         console.log('HTTPError', err.response.statusCode, err.response.body)
+      if(err instanceof TRPCError) throw err
     }
   }
 

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendWhatsappSocketMessage.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendWhatsappSocketMessage.ts
@@ -1,5 +1,6 @@
 import { env } from '@typebot.io/env'
 import { Socket, io } from 'socket.io-client'
+import { WhatsappOperationTypes } from './WhatsappOperationType'
 import { WhatsappSocketSendingMessage } from "./convertMessageToWhatsappCompoent"
 
 type SendMessagePayload = {
@@ -13,7 +14,8 @@ export async function sendSocketWhatsappMessage(clientId: string, { message, pho
     const socket = io(env.WHATSAPP_SERVER, {
       autoConnect: true,
       query: {
-        clientId
+        clientId,
+        operationType: WhatsappOperationTypes.SEND_MESSAGE
       }
     })
 

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendWhatsappSocketMessage.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendWhatsappSocketMessage.ts
@@ -42,5 +42,6 @@ export async function sendSocketWhatsappMessage(clientId: string, { message, pho
     })
   })
 
+  await new Promise((resolve) => setTimeout(resolve, 100))
   socketClient.close()
 }

--- a/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendWhatsappSocketMessage.ts
+++ b/packages/bot-engine/whatsapp/WhatsappComponentFlow/sendWhatsappSocketMessage.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from '@trpc/server'
 import { env } from '@typebot.io/env'
 import { Socket, io } from 'socket.io-client'
 import { WhatsappOperationTypes } from './WhatsappOperationType'
@@ -21,7 +22,7 @@ export async function sendSocketWhatsappMessage(clientId: string, { message, pho
 
     socket.on('qr', () => {
       socket.close()
-      reject(new Error('Session expired, please configure again the whatsapp credentials'))
+      reject(new TRPCError({ code: 'BAD_REQUEST', message: 'Sessão expirada, por favor configure novamente o qr code do seu whatsapp'}))
     })
 
     socket.on('ready', () => {


### PR DESCRIPTION
# Adicionei "Operation Types" para que eu identifique o intuito da conexão websocket

Porquê?
- Basicamente o evento de qr code pode acontecer tanto quando o cara quer gerar um novo qr code para cadastrar seu whatsapp QUANTO quando o usuário deseja enviar uma mensagem, porém o qr code é gerado pois sua sessão expirou.
- Com essas informações consigo ter maior clareza e remover as conexões e clientes desnecessários quando o intuito do usuário for gerar um novo qrcode