### PR TITLE
[FH-17] - Ajuste do bloco do cal.com

### DIFF
--- a/packages/forge/blocks/calCom/actions/bookEvent.ts
+++ b/packages/forge/blocks/calCom/actions/bookEvent.ts
@@ -8,7 +8,7 @@ export const bookEvent = createAction({
   options: option.object({
     link: option.string.layout({
       label: 'Event link',
-      placeholder: 'https://cal.com/...',
+      placeholder: 'https://calendar.funnelhub.io/...',
     }),
     layout: option
       .enum(['Month', 'Weekly', 'Columns'])

--- a/packages/forge/blocks/calCom/baseOptions.ts
+++ b/packages/forge/blocks/calCom/baseOptions.ts
@@ -4,7 +4,7 @@ import { defaultBaseUrl } from './constants'
 export const baseOptions = option.object({
   baseUrl: option.string.layout({
     label: 'Base origin',
-    placeholder: 'https://cal.com',
+    placeholder: 'https://calendar.funnelhub.io',
     defaultValue: defaultBaseUrl,
     accordion: 'Customize host',
   }),

--- a/packages/forge/blocks/calCom/constants.ts
+++ b/packages/forge/blocks/calCom/constants.ts
@@ -1,1 +1,1 @@
-export const defaultBaseUrl = 'https://app.cal.com'
+export const defaultBaseUrl = 'https://calendar.funnelhub.io'

--- a/packages/forge/blocks/calCom/index.ts
+++ b/packages/forge/blocks/calCom/index.ts
@@ -5,7 +5,7 @@ import { baseOptions } from './baseOptions'
 
 export const calCom = createBlock({
   id: 'cal-com',
-  name: 'Cal.com',
+  name: 'Calendário',
   tags: ['calendar', 'scheduling', 'meetings'],
   LightLogo: CalComLogo,
   options: baseOptions,


### PR DESCRIPTION
- Troca do nome do bloco para "Calendário"
- Substituição da url padrão.
![image](https://github.com/funnelhub-io/typebot.io/assets/110189424/12154eee-6d5a-4cde-802e-f8f23391c55a)
