### PR TITLE
Fix/call whatsapp bot by endpoint api

### DIFF
--- a/apps/viewer/src/features/chat/api/startChat.ts
+++ b/apps/viewer/src/features/chat/api/startChat.ts
@@ -28,6 +28,7 @@ export const startChat = publicProcedure
         isStreamEnabled,
         prefilledVariables,
         resultId: startResultId,
+        isWhatsappIntegration,
       },
       ctx: { origin, res },
     }) => {
@@ -50,6 +51,7 @@ export const startChat = publicProcedure
           publicId,
           prefilledVariables,
           resultId: startResultId,
+          isWhatsappIntegration,
         },
         message,
       })

--- a/apps/viewer/src/features/chat/api/startChatPreview.ts
+++ b/apps/viewer/src/features/chat/api/startChatPreview.ts
@@ -29,6 +29,7 @@ export const startChatPreview = publicProcedure
         startFrom,
         typebotId,
         typebot: startTypebot,
+        isWhatsappIntegration,
       },
       ctx: { user },
     }) => {
@@ -51,6 +52,7 @@ export const startChatPreview = publicProcedure
           typebotId,
           typebot: startTypebot,
           userId: user?.id,
+          isWhatsappIntegration,
         },
         message,
       })

--- a/apps/viewer/src/test/chat.spec.ts
+++ b/apps/viewer/src/test/chat.spec.ts
@@ -1,15 +1,15 @@
 import { getTestAsset } from '@/test/utils/playwright'
-import test, { expect } from '@playwright/test'
 import { createId } from '@paralleldrive/cuid2'
-import prisma from '@typebot.io/lib/prisma'
+import test, { expect } from '@playwright/test'
 import {
   createWebhook,
   deleteTypebots,
   deleteWebhooks,
   importTypebotInDatabase,
 } from '@typebot.io/lib/playwright/databaseActions'
-import { HttpMethod } from '@typebot.io/schemas/features/blocks/integrations/webhook/constants'
+import prisma from '@typebot.io/lib/prisma'
 import { StartChatInput, StartPreviewChatInput } from '@typebot.io/schemas'
+import { HttpMethod } from '@typebot.io/schemas/features/blocks/integrations/webhook/constants'
 
 test.afterEach(async () => {
   await deleteWebhooks(['chat-webhook-id'])
@@ -48,6 +48,7 @@ test('API chat execution should work on preview bot', async ({ request }) => {
         data: {
           isOnlyRegistering: false,
           isStreamEnabled: false,
+          isWhatsappIntegration: false,
         } satisfies Omit<StartPreviewChatInput, 'typebotId'>,
       })
     ).json()
@@ -120,6 +121,7 @@ test('API chat execution should work on published bot', async ({ request }) => {
         data: {
           isOnlyRegistering: false,
           isStreamEnabled: false,
+          isWhatsappIntegration: false,
         } satisfies Omit<StartChatInput, 'publicId'>,
       })
     ).json()
@@ -302,6 +304,7 @@ test('API chat execution should work on published bot', async ({ request }) => {
             message: 'Hey',
             isStreamEnabled: false,
             isOnlyRegistering: false,
+            isWhatsappIntegration: false,
           } satisfies Omit<StartChatInput, 'publicId'>,
         }
       )

--- a/packages/bot-engine/blocks/integrations/whatsapp/executeWhatsappBlock.ts
+++ b/packages/bot-engine/blocks/integrations/whatsapp/executeWhatsappBlock.ts
@@ -1,22 +1,25 @@
-import { decrypt } from "@typebot.io/lib/api/encryption/decrypt";
-import prisma from "@typebot.io/lib/prisma";
-import { ChatLog, SessionState, Variable, WhatsappBlock, WhatsappCredentials } from "@typebot.io/schemas";
-import { parseVariables } from '@typebot.io/variables/parseVariables';
-import { ExecuteIntegrationResponse } from "../../../types";
+import { decrypt } from '@typebot.io/lib/api/encryption/decrypt'
+import prisma from '@typebot.io/lib/prisma'
+import {
+  ChatLog,
+  SessionState,
+  Variable,
+  WhatsappBlock,
+  WhatsappCredentials,
+} from '@typebot.io/schemas'
+import { parseVariables } from '@typebot.io/variables/parseVariables'
+import { ExecuteIntegrationResponse } from '../../../types'
 
 export const executeWhatsappBlock = async (
   state: SessionState,
-  {
-    outgoingEdgeId,
-    options,
-  }: WhatsappBlock
+  { outgoingEdgeId, options }: WhatsappBlock
 ): Promise<ExecuteIntegrationResponse> => {
   const noCredentialsError = {
     status: 'error',
     description: 'Missing whatsapp credentials',
   }
 
-  if(!options?.phone) {
+  if (!options?.phone) {
     return {
       outgoingEdgeId,
       logs: [
@@ -60,23 +63,36 @@ export const executeWhatsappBlock = async (
     credentials.iv
   )) as WhatsappCredentials['data']
 
-  return { 
-    outgoingEdgeId, 
-    logs, 
-    newSessionState: { 
-      ...state, 
-      whatsappComponent: { 
-        phone: phoneWithVariable, 
-        clientId, 
-        canExecute: false 
+  return state.isWhatsappIntegration
+    ? {
+        outgoingEdgeId,
+        logs,
+        newSessionState: {
+          ...state,
+          whatsappComponent: {
+            phone: phoneWithVariable,
+            clientId,
+            canExecute: true,
+          },
+        },
       }
-    }, 
-    clientSideActions: [
-      { 
-        type: 'whatsappComponent', 
-        whatsappComponent: { clientId }, 
-        expectsDedicatedReply: true 
+    : {
+        outgoingEdgeId,
+        logs,
+        newSessionState: {
+          ...state,
+          whatsappComponent: {
+            phone: phoneWithVariable,
+            clientId,
+            canExecute: false,
+          },
+        },
+        clientSideActions: [
+          {
+            type: 'whatsappComponent',
+            whatsappComponent: { clientId },
+            expectsDedicatedReply: true,
+          },
+        ],
       }
-    ] 
-  } 
 }

--- a/packages/bot-engine/blocks/integrations/whatsapp/executeWhatsappBlock.ts
+++ b/packages/bot-engine/blocks/integrations/whatsapp/executeWhatsappBlock.ts
@@ -63,7 +63,7 @@ export const executeWhatsappBlock = async (
     credentials.iv
   )) as WhatsappCredentials['data']
 
-  return state.isWhatsappIntegration
+  return !!state?.isWhatsappIntegration
     ? {
         outgoingEdgeId,
         logs,

--- a/packages/bot-engine/startSession.ts
+++ b/packages/bot-engine/startSession.ts
@@ -23,6 +23,10 @@ import {
 } from '@typebot.io/schemas/features/chat/schema'
 import { defaultSettings } from '@typebot.io/schemas/features/typebot/settings/constants'
 import { defaultTheme } from '@typebot.io/schemas/features/typebot/theme/constants'
+import { deepParseVariables } from '@typebot.io/variables/deepParseVariables'
+import { injectVariablesFromExistingResult } from '@typebot.io/variables/injectVariablesFromExistingResult'
+import { parseVariables } from '@typebot.io/variables/parseVariables'
+import { prefillVariables } from '@typebot.io/variables/prefillVariables'
 import parse, { NodeType } from 'node-html-parser'
 import { continueBotFlow } from './continueBotFlow'
 import { getNextGroup } from './getNextGroup'
@@ -32,10 +36,6 @@ import { findResult } from './queries/findResult'
 import { findTypebot } from './queries/findTypebot'
 import { upsertResult } from './queries/upsertResult'
 import { startBotFlow } from './startBotFlow'
-import { deepParseVariables } from '@typebot.io/variables/deepParseVariables'
-import { injectVariablesFromExistingResult } from '@typebot.io/variables/injectVariablesFromExistingResult'
-import { parseVariables } from '@typebot.io/variables/parseVariables'
-import { prefillVariables } from '@typebot.io/variables/prefillVariables'
 
 type StartParams =
   | ({
@@ -50,7 +50,10 @@ type Props = {
   version: 1 | 2
   message: string | undefined
   startParams: StartParams
-  initialSessionState?: Pick<SessionState, 'whatsApp' | 'expiryTimeout' | 'whatsappComponent' | 'sessionId'>
+  initialSessionState?: Pick<
+    SessionState,
+    'whatsApp' | 'expiryTimeout' | 'whatsappComponent' | 'sessionId'
+  >
 }
 
 export const startSession = async ({
@@ -136,6 +139,7 @@ export const startSession = async ({
         ? undefined
         : typebot.settings.security?.allowedOrigins,
     ...initialSessionState,
+    isWhatsappIntegration: startParams.isWhatsappIntegration,
   }
 
   if (startParams.isOnlyRegistering) {

--- a/packages/embeds/js/src/queries/startChatQuery.ts
+++ b/packages/embeds/js/src/queries/startChatQuery.ts
@@ -1,10 +1,10 @@
-import { BotContext, InitialChatReply } from '@/types'
-import { guessApiHost } from '@/utils/guessApiHost'
-import { isNotDefined, isNotEmpty } from '@typebot.io/lib'
 import {
   getPaymentInProgressInStorage,
   removePaymentInProgressFromStorage,
 } from '@/features/blocks/inputs/payment/helpers/paymentInProgressStorage'
+import { BotContext, InitialChatReply } from '@/types'
+import { guessApiHost } from '@/utils/guessApiHost'
+import { isNotDefined, isNotEmpty } from '@typebot.io/lib'
 import {
   StartChatInput,
   StartFrom,
@@ -82,6 +82,7 @@ export async function startChatQuery({
               isStreamEnabled: true,
               startFrom,
               typebot,
+              isWhatsappIntegration: false,
             } satisfies Omit<StartPreviewChatInput, 'typebotId'>,
             timeout: false,
           }
@@ -106,6 +107,7 @@ export async function startChatQuery({
             prefilledVariables,
             resultId,
             isOnlyRegistering: false,
+            isWhatsappIntegration: false,
           } satisfies Omit<StartChatInput, 'publicId'>,
           timeout: false,
         }

--- a/packages/schemas/features/chat/schema.ts
+++ b/packages/schemas/features/chat/schema.ts
@@ -13,21 +13,21 @@ import {
   textInputSchema,
   urlInputSchema,
 } from '../blocks'
-import { logSchema } from '../result'
-import { settingsSchema, themeSchema } from '../typebot'
 import {
-  textBubbleContentSchema,
-  imageBubbleContentSchema,
-  videoBubbleContentSchema,
   audioBubbleContentSchema,
   embedBubbleContentSchema,
+  imageBubbleContentSchema,
+  textBubbleContentSchema,
+  videoBubbleContentSchema,
 } from '../blocks/bubbles'
-import { sessionStateSchema } from './sessionState'
-import { dynamicThemeSchema } from './shared'
+import { BubbleBlockType } from '../blocks/bubbles/constants'
+import { logSchema } from '../result'
+import { settingsSchema, themeSchema } from '../typebot'
 import { preprocessTypebot } from '../typebot/helpers/preprocessTypebot'
 import { typebotV5Schema, typebotV6Schema } from '../typebot/typebot'
-import { BubbleBlockType } from '../blocks/bubbles/constants'
 import { clientSideActionSchema } from './clientSideAction'
+import { sessionStateSchema } from './sessionState'
+import { dynamicThemeSchema } from './shared'
 
 const chatSessionSchema = z.object({
   id: z.string(),
@@ -203,6 +203,7 @@ export const startChatInputSchema = z.object({
         Email: 'john@gmail.com',
       },
     }),
+  isWhatsappIntegration: z.boolean().optional().default(false),
 })
 export type StartChatInput = z.infer<typeof startChatInputSchema>
 
@@ -238,6 +239,7 @@ export const startPreviewChatInputSchema = z.object({
       'If set, it will override the typebot that is used to start the chat.'
     ),
   startFrom: startFromSchema.optional(),
+  isWhatsappIntegration: z.boolean().optional().default(false),
 })
 export type StartPreviewChatInput = z.infer<typeof startPreviewChatInputSchema>
 

--- a/packages/schemas/features/chat/sessionState.ts
+++ b/packages/schemas/features/chat/sessionState.ts
@@ -46,6 +46,7 @@ const sessionStateSchemaV1 = z.object({
     })
     .optional(),
   isStreamEnabled: z.boolean().optional(),
+  isWhatsappIntegration: z.boolean().optional().default(false),
 })
 
 const sessionStateSchemaV2 = z.object({
@@ -74,11 +75,14 @@ const sessionStateSchemaV2 = z.object({
       }),
     })
     .optional(),
-  whatsappComponent: z.object({
-    phone: z.string(),
-    clientId: z.string(),
-    canExecute: z.boolean()
-  }).optional(),
+  whatsappComponent: z
+    .object({
+      phone: z.string(),
+      clientId: z.string(),
+      canExecute: z.boolean(),
+    })
+    .optional(),
+  isWhatsappIntegration: z.boolean().optional().default(false),
   expiryTimeout: z
     .number()
     .min(1)
@@ -161,6 +165,7 @@ const migrateFromV1ToV2 = (
   dynamicTheme: state.dynamicTheme,
   currentBlock: state.currentBlock,
   isStreamEnabled: state.isStreamEnabled,
+  isWhatsappIntegration: false,
 })
 
 const migrateFromV2ToV3 = (


### PR DESCRIPTION
# Iniciar chat de whatsapp via api.

- Para iniciar o chat de mensagens que INICIAM pelo bloco de integração do whatsapp foi adicionado um campo novo no body da requisição chamado isWhatsappIntegration com isso ao realizar uma requisição poderemos chamar diretamente a automação de whatsapp sem a necessidade de browser.
Exemplo de requisição:
```bash
curl --request POST \
  --url https://localhost:3001/api/v1/typebots/my-typebot-tfeip88/startChat \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/2023.5.8' \
  --data '{
	"isWhatsappIntegration": true
}'
```