### PR TITLE
[FH - 62] - Correção de erro no Typebot

### DIFF
--- a/apps/builder/src/features/account/UserProvider.tsx
+++ b/apps/builder/src/features/account/UserProvider.tsx
@@ -58,7 +58,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
       localStorage.getItem('currentWorkspaceId') ?? undefined
     )
 
-    const parsedUser = session.user as User & {
+    const parsedUser = { ...session.user } as User & {
       apiToken?: string | null
       locale?: string | null
       currentWorkspace?: object


### PR DESCRIPTION
Correção do erro no Typebot ao clicar em voltar à partir de um bot no editor.

Ao aplicar o delete nas chaves do objeto parsedUser, ele também deletava no objeto user dentro de session porque ambos possuíam o mesmo endereço na memória.
A solução foi fazer uma cópia do session.user para o parsedUser.